### PR TITLE
Support for obtaining lists of results via snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ import Control.Monad.IO.Class
 import System.Statgrab
 
 main :: IO ()
-main = runStats $ (snapshot :: Stats Host) >>= liftIO . print
+main = do
+ runStats $ (snapshot :: Stats Host) >>= liftIO . print
+ runStats $ (snapshots :: Stats [NetworkInterface]) >>= liftIO . print
 ```
 
 

--- a/src/System/Statgrab.hs
+++ b/src/System/Statgrab.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
 
 -- Module      : System.Statgrab
 -- Copyright   : (c) 2013 Brendan Hay <brendan.g.hay@gmail.com>
@@ -22,6 +23,7 @@ module System.Statgrab
 
      -- * Retrieving Statistics
     , snapshot
+    , snapshots
     , Stat
     , Struct
 
@@ -93,8 +95,14 @@ async (Stats s) = Stats $ do
 --
 -- The *_r variants of the libstatgrab functions are used and
 -- the deallocation strategy is bracketed.
+
 snapshot :: (Stat (Struct a), Copy a) => Stats a
-snapshot = liftIO $ bracket acquire release copy
+snapshot = liftIO $ bracket (_acquire acquire) (_release release) copy
+
+-- | Similar to 'snapshot'. 'snapshots' returns a list of results.
+
+snapshots :: (Stat (Struct a), Copy a) => Stats [a]
+snapshots = liftIO $ bracket (_acquire acquire) (_release release) copyBatch
 
 --
 -- Internal

--- a/src/System/Statgrab.hs
+++ b/src/System/Statgrab.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards            #-}
 
 -- Module      : System.Statgrab
 -- Copyright   : (c) 2013 Brendan Hay <brendan.g.hay@gmail.com>

--- a/src/System/Statgrab/Base.hsc
+++ b/src/System/Statgrab/Base.hsc
@@ -1097,8 +1097,8 @@ instance Storable (Struct Process) where
         #{poke sg_process_stats, systime} p procSystime
 
 instance Stat (Struct Process) where
- acquire = sg_get_process_stats_r
- release = sg_free_process_stats
+    acquire = sg_get_process_stats_r
+    release = sg_free_process_stats
 
 foreign import ccall safe "statgrab.h sg_get_process_stats"
     sg_get_process_stats :: Entries -> IO ProcessPtr

--- a/statgrab.cabal
+++ b/statgrab.cabal
@@ -46,7 +46,6 @@ library
     exposed-modules:
         System.Statgrab
         System.Statgrab.Base
-        System.Statgrab.Internal
 
     ghc-options:
         -Wall -O2

--- a/statgrab.cabal
+++ b/statgrab.cabal
@@ -45,10 +45,8 @@ library
 
     exposed-modules:
         System.Statgrab
-
-    other-modules:
         System.Statgrab.Base
-      , System.Statgrab.Internal
+        System.Statgrab.Internal
 
     ghc-options:
         -Wall -O2


### PR DESCRIPTION
Hey Brendan,

I was going to contact you and ask how this could be done in the current library, but instead I figured i'd just try to implement it and then see if it makes sense. I learned alot in the process; this is the first time i have used the Haskell C FFI.

Basically, I have added modifications that will allow you to obtain a list of results by calling the "snapshots" function. For example, you can obtain a full process list via:

runStats $ (snapshots :: Stats [Process]) >>= liftIO . print

"snapshots" will work with any of the statgrab data types. If a function only returns one value, it will be contained within a list. So there's no danger in calling it against Stats [Host] for example.

Also, everything remains backward compatible with the existing library. "snapshot" works just as it did before. I tried to achieve this in what I figured to be the most elegant way possible. IMHO it came out somewhat decent, only minor changes were made across all of the Stat & Copy instances.

One thing you may not like is the fact that I made System.Statgrab.Internal available. This was done so that I (or others) could more easily marshall/unmarshall statgrab structures into json etc. For example, here is a separate library I wrote to do just that:

https://github.com/adarqui/DevUtils-Statgrab/blob/master/examples/ex1.hs
https://github.com/adarqui/DevUtils-Statgrab/blob/master/src/System/DevUtils/Statgrab.hs

If you would like to accept this pull request but need me to make some changes, please let me know. If not, that's cool too.

Thanks for writing this library. It's been extremely helpful.

-- Andrew
